### PR TITLE
Add ARM64 enum to ProcessorArchitecture.cs

### DIFF
--- a/src/Common/src/CoreLib/System/Reflection/ProcessorArchitecture.cs
+++ b/src/Common/src/CoreLib/System/Reflection/ProcessorArchitecture.cs
@@ -11,6 +11,7 @@ namespace System.Reflection
         X86 = 0x0002,
         IA64 = 0x0003,
         Amd64 = 0x0004,
-        Arm = 0x0005
+        Arm = 0x0005,
+        Arm64 = 0x0006
     }
 }


### PR DESCRIPTION
Updating the ProcessorArchitecture enum to add ARM64